### PR TITLE
Placed extensions in the correct location

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ libraryDependencies ++= Seq(
 2) Update application.conf
 ```scala
 akka {
+  extensions = ["com.romix.akka.serialization.kryo.KryoSerializationExtension$"]
   actor {
-    extensions = ["com.romix.akka.serialization.kryo.KryoSerializationExtension$"]
     serializers {
       kryo = "com.romix.akka.serialization.kryo.KryoSerializer"
     }


### PR DESCRIPTION
Extensions should be defined inside `akka` object, not inside `akka.actor`. This is [mentioned in the documentation](https://doc.akka.io/docs/akka/2.5/extending-akka.html#loading-from-configuration)